### PR TITLE
debian: install FindKurentoModuleCreator.cmake for cmake-3.18

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -5,3 +5,4 @@ target/classes/FindKurentoModuleCreator.cmake /usr/share/cmake-3.0/Modules/
 target/classes/FindKurentoModuleCreator.cmake /usr/share/cmake-3.2/Modules/
 target/classes/FindKurentoModuleCreator.cmake /usr/share/cmake-3.5/Modules/
 target/classes/FindKurentoModuleCreator.cmake /usr/share/cmake-3.10/Modules/
+target/classes/FindKurentoModuleCreator.cmake /usr/share/cmake-3.18/Modules/


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
Building the rest of Kurento on a Debian 11 system, it can not find ```FindKurentoModuleCreator.cmake``` from this package because it is not in the cmake-3.18 directory


## What is the new behavior provided by this change?
put a copy of the file in the cmake-3.18 directory so that the builds succeed

## How has this been tested?
built all of the Kurento packages on Debian 11 with CMake 3.18


## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
