### PR TITLE
Kurento 7.0: Drop dependency on forked jsoncpp library

### DIFF
--- a/src/main/java/org/kurento/modulecreator/codegen/function/JsonCppTypeData.java
+++ b/src/main/java/org/kurento/modulecreator/codegen/function/JsonCppTypeData.java
@@ -32,11 +32,16 @@ public class JsonCppTypeData implements TemplateMethodModelEx {
 
   public class JsonTypeData {
     String jsonMethod;
+    String jsonValueCheck;
     String jsonValueType;
     String typeDescription;
 
     public String getJsonMethod() {
       return jsonMethod;
+    }
+
+    public String getJsonValueCheck() {
+      return jsonValueCheck;
     }
 
     public String getJsonValueType() {
@@ -72,43 +77,50 @@ public class JsonCppTypeData implements TemplateMethodModelEx {
       if (typeRef.isList()) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "List";
+        data.jsonValueCheck = "isArray";
         data.jsonValueType = "arrayValue";
         data.typeDescription = "list";
         return data;
       } else if (typeRef.isMap()) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "Map";
+        data.jsonValueCheck = "isObject";
         data.jsonValueType = "objectValue";
         data.typeDescription = "map";
         return data;
       } else if (typeRef.getName().equals("String")) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "String";
+        data.jsonValueCheck = "isString";
         data.jsonValueType = "stringValue";
         data.typeDescription = "string";
         return data;
       } else if (typeRef.getName().equals("int")) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "Int";
+        data.jsonValueCheck = "isInt";
         data.jsonValueType = "intValue";
         data.typeDescription = "integer";
         return data;
       } else if (typeRef.getName().equals("boolean")) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "Bool";
+        data.jsonValueCheck = "isBool";
         data.jsonValueType = "booleanValue";
         data.typeDescription = "boolean";
         return data;
       } else if (typeRef.getName().equals("double") || typeRef.getName().equals("float")) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "Double";
+        data.jsonValueCheck = "isDouble";
         data.jsonValueType = "realValue";
         data.typeDescription = "double";
         return data;
       } else if (typeRef.getName().equals("int64")) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "Int64";
-        data.jsonValueType = "int64Value";
+        data.jsonValueCheck = "isInt64";
+        data.jsonValueType = "intValue";
         data.typeDescription = "int64";
         return data;
       } else if (typeRef.getType() instanceof ComplexType) {
@@ -117,12 +129,14 @@ public class JsonCppTypeData implements TemplateMethodModelEx {
         if (complexType.getTypeFormat() == TypeFormat.ENUM) {
           JsonTypeData data = new JsonTypeData();
           data.jsonMethod = "String";
+          data.jsonValueCheck = "isString";
           data.jsonValueType = "stringValue";
           data.typeDescription = "string";
           return data;
         } else if (complexType.getTypeFormat() == TypeFormat.REGISTER) {
           JsonTypeData data = new JsonTypeData();
           data.jsonMethod = "Object";
+          data.jsonValueCheck = "isObject";
           data.jsonValueType = "objectValue";
           data.typeDescription = "object";
           return data;
@@ -130,6 +144,7 @@ public class JsonCppTypeData implements TemplateMethodModelEx {
       } else if (typeRef.getType() instanceof RemoteClass) {
         JsonTypeData data = new JsonTypeData();
         data.jsonMethod = "String";
+        data.jsonValueCheck = "isString";
         data.jsonValueType = "stringValue";
         data.typeDescription = "string";
         return data;

--- a/src/main/templates/cpp_interface/complexType_class_cpp.ftl
+++ b/src/main/templates/cpp_interface/complexType_class_cpp.ftl
@@ -65,7 +65,7 @@ void ${complexType.name}::Serialize (JsonSerializer &s)
     <#assign jsonData = getJsonCppTypeData(property.type)>
     <#if property.optional>
     if (s.JsonValue.isMember ("${property.name}") ) {
-      if (s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+      if (s.JsonValue["${property.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()})) {
         __isSet${property.name?cap_first} = true;
         s.SerializeNVP (${property.name});
       } else {
@@ -77,7 +77,7 @@ void ${complexType.name}::Serialize (JsonSerializer &s)
       Json::Reader reader;
       std::string defaultValue = "${escapeString (property.defaultValue)}";
       reader.parse (defaultValue, s.JsonValue["${property.name}"]);
-      if (s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+      if (s.JsonValue["${property.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()})) {
         __isSet${property.name?cap_first} = true;
         s.SerializeNVP (${property.name});
       } else {
@@ -88,7 +88,7 @@ void ${complexType.name}::Serialize (JsonSerializer &s)
     }
 
     <#else>
-    if (!s.JsonValue.isMember ("${property.name}") || !s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+    if (!s.JsonValue.isMember ("${property.name}") || !(s.JsonValue["${property.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}))) {
       throw KurentoException (MARSHALL_ERROR,
                               "'${property.name}' property should be a ${jsonData.getTypeDescription()}");
     }

--- a/src/main/templates/cpp_interface_internal/remoteClass_internal_cpp.ftl
+++ b/src/main/templates/cpp_interface_internal/remoteClass_internal_cpp.ftl
@@ -84,7 +84,7 @@ void ${remoteClass.name}Method${method.name?cap_first}::Serialize (kurento::Json
     <#assign jsonData = getJsonCppTypeData(param.type)>
     <#if param.optional>
     if (s.JsonValue.isMember ("${param.name}") ) {
-      if (s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+      if (s.JsonValue["${param.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()})) {
         __isSet${param.name?cap_first} = true;
         s.SerializeNVP (${param.name});
       } else {
@@ -94,7 +94,7 @@ void ${remoteClass.name}Method${method.name?cap_first}::Serialize (kurento::Json
     }
 
     <#else>
-    if (!s.JsonValue.isMember ("${param.name}") || !s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+    if (!s.JsonValue.isMember ("${param.name}") || !(s.JsonValue["${param.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}))) {
       throw KurentoException (MARSHALL_ERROR,
                               "'${param.name}' parameter should be a ${jsonData.getTypeDescription()}");
     }
@@ -175,7 +175,7 @@ void ${remoteClass.name}Constructor::Serialize (kurento::JsonSerializer &s)
     <#assign jsonData = getJsonCppTypeData(param.type)>
     <#if param.optional>
     if (s.JsonValue.isMember ("${param.name}") ) {
-      if (s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+      if (s.JsonValue["${param.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()})) {
         __isSet${param.name?cap_first} = true;
         s.SerializeNVP (${param.name});
       } else {
@@ -185,7 +185,7 @@ void ${remoteClass.name}Constructor::Serialize (kurento::JsonSerializer &s)
     }
 
     <#else>
-    if (!s.JsonValue.isMember ("${param.name}") || !s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+    if (!s.JsonValue.isMember ("${param.name}") || !(s.JsonValue["${param.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${param.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}))) {
       throw KurentoException (MARSHALL_ERROR,
                               "'${param.name}' parameter should be a ${jsonData.getTypeDescription()}");
     }

--- a/src/main/templates/cpp_server_internal/remoteClass_internal_cpp.ftl
+++ b/src/main/templates/cpp_server_internal/remoteClass_internal_cpp.ftl
@@ -84,7 +84,7 @@ ${remoteClass.name}Impl::invoke (std::shared_ptr<MediaObjectImpl> obj, const std
     s.JsonValue = params;
 
 <#assign jsonData = getJsonCppTypeData(property.type)>
-    if (!s.JsonValue.isMember ("${property.name}") || !s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}) ) {
+    if (!s.JsonValue.isMember ("${property.name}") || !(s.JsonValue["${property.name}"].${jsonData.getJsonValueCheck()} () || s.JsonValue["${property.name}"].isConvertibleTo (Json::ValueType::${jsonData.getJsonValueType()}))) {
       throw KurentoException (MARSHALL_ERROR,
                               "'${property.name}' parameter should be a ${jsonData.getTypeDescription()}");
     }
@@ -181,7 +181,7 @@ Serialize (std::shared_ptr<${module.code.implementation["cppNamespace"]}::${remo
     }
   } else {
     std::shared_ptr<kurento::MediaObjectImpl> aux;
-    aux = ${module.code.implementation["cppNamespace"]}::${remoteClass.name}ImplFactory::getObject (JsonFixes::getString(serializer.JsonValue) );
+    aux = ${module.code.implementation["cppNamespace"]}::${remoteClass.name}ImplFactory::getObject (serializer.JsonValue.asString());
     object = std::dynamic_pointer_cast<${module.code.implementation["cppNamespace"]}::${remoteClass.name}Impl> (aux);
   }
 }


### PR DESCRIPTION
Kurento has always used a customized fork of the [jsoncpp](https://github.com/open-source-parsers/jsoncpp) library: [kmsjsoncpp](https://github.com/Kurento/jsoncpp), which consists on the upstream version 1.6.3 plus some modifications on top of it:

* [Convert string to numbers when possible (90ea316)](https://github.com/Kurento/jsoncpp/commit/90ea316d71405ba748ededadf228eb19be215589)

    This was, in my opinion, a Bad Idea™. Automatically converting all strings to their integer representation is something that belongs to the end application, and has no place in a JSON parsing library. The authors of *jsoncpp* have indeed rejected adding this feature in several occasions, with good reasons:

    * [#270 Convert string to numbers when possible](https://github.com/open-source-parsers/jsoncpp/pull/270)
    * [#477 Add string conversion to other types](https://github.com/open-source-parsers/jsoncpp/pull/477)
    
    Kurento relies on the automatic conversion of strings to integers, so this change brings this conversion into the adequate place within the module that parses JSON values.

* [Add int64Value data (8b2dfcc)](https://github.com/Kurento/jsoncpp/commit/8b2dfccf844ced7cbd93038eafcbb4139324f282)

    Adding `int64Value` to the enum of possible types was, IMHO, a more reasonable change, because otherwise the class method `Json::Value::isConvertibleTo({Type})` is rendered unreliable and code needs to complement all calls to it with an extra call to the `is{Type}()` kind of methods. I opened a discussion around this topic, here:
    
    [Why isConvertibleTo never supported int64Value?](https://github.com/open-source-parsers/jsoncpp/discussions/1436).
    
    All of the generic code templates that Kurento Module Creator uses for code generation, used the `isConvertibleTo()` method to verify value types. Given that this method is unreliable for `int64`, all of those calls have been complemented with explicit calls to `is{Type}()`

Linked PRs:

* https://github.com/Kurento/kms-jsonrpc/pull/6
* https://github.com/Kurento/kurento-module-creator/pull/9
* https://github.com/Kurento/kurento-media-server/pull/24

Closes https://github.com/Kurento/bugtracker/issues/602
